### PR TITLE
Fix detektPlugin: Apply detekt to projects with plugin kotlin-base (not java-base)

### DIFF
--- a/plugins/detekt-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/detekt/DetektPlugin.groovy
+++ b/plugins/detekt-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/detekt/DetektPlugin.groovy
@@ -78,7 +78,7 @@ class DetektPlugin extends AbstractKordampPlugin {
         BasePlugin.applyIfMissing(project)
         project.pluginManager.apply(io.gitlab.arturbosch.detekt.DetektPlugin)
 
-        project.pluginManager.withPlugin('java-base', new Action<AppliedPlugin>() {
+        project.pluginManager.withPlugin('kotlin-base', new Action<AppliedPlugin>() {
             @Override
             void execute(AppliedPlugin appliedPlugin) {
 


### PR DESCRIPTION
DetektPlugin should be enabled for project with plugin `kotlin-base`, not `java-base`.

Merging this PR successfully builds my current PR https://github.com/ursjoss/kordamp-gradle-test-suite/pull/1 (tested locally)