### PR TITLE
Detekt: configuration Parameter failFast

### DIFF
--- a/docs/guide/src/docs/asciidoc/plugins/detekt-gradle-plugin.adoc
+++ b/docs/guide/src/docs/asciidoc/plugins/detekt-gradle-plugin.adoc
@@ -25,6 +25,7 @@ config {
             configFile
             baselineFile
             parallel
+            failFast
             buildUponDefaultConfig
             disableDefaultRuleSets
             toolVersion
@@ -44,6 +45,7 @@ config {
 | configFile             | Set<String> | no       |               |
 | baselineFile           | Set<String> | no       |               |
 | parallel               | boolean     | no       | yes           |
+| failFast               | boolean     | no       | no            |
 | buildUponDefaultConfig | boolean     | no       | no            |
 | disableDefaultRuleSets | boolean     | no       | no            |
 | toolVersion            | String      | no       | 1.2.2         |

--- a/plugins/base-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/base/plugins/Detekt.groovy
+++ b/plugins/base-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/base/plugins/Detekt.groovy
@@ -37,10 +37,12 @@ class Detekt extends AbstractQualityFeature {
     boolean parallel = true
     boolean buildUponDefaultConfig = false
     boolean disableDefaultRuleSets = false
+    boolean failFast = false
 
     private boolean parallelSet
     private boolean buildUponDefaultConfigSet
     private boolean disableDefaultRuleSetsSet
+    private boolean failFastSet
 
     Detekt(ProjectConfigurationExtension config, Project project) {
         super(config, project, PLUGIN_ID, 'detekt')
@@ -53,6 +55,7 @@ class Detekt extends AbstractQualityFeature {
         map.configFile = this.configFile
         map.baselineFile = this.baselineFile
         map.parallel = this.parallel
+        map.failFast = this.failFast
         map.buildUponDefaultConfig = this.buildUponDefaultConfig
         map.disableDefaultRuleSets = this.disableDefaultRuleSets
     }
@@ -89,6 +92,15 @@ class Detekt extends AbstractQualityFeature {
         this.parallelSet
     }
 
+    void setFailFast(boolean failFast) {
+        this.failFast = failFast
+        this.failFastSet = true
+    }
+
+    boolean isFailFastSet() {
+        this.failFastSet
+    }
+
     void setBuildUponDefaultConfig(boolean buildUponDefaultConfig) {
         this.buildUponDefaultConfig = buildUponDefaultConfig
         this.buildUponDefaultConfigSet = true
@@ -111,6 +123,8 @@ class Detekt extends AbstractQualityFeature {
         super.copyInto(copy)
         copy.@parallel = parallel
         copy.@parallelSet = parallelSet
+        copy.@failFast = failFast
+        copy.@failFastSet = failFastSet
         copy.@buildUponDefaultConfig = buildUponDefaultConfig
         copy.@buildUponDefaultConfigSet = buildUponDefaultConfigSet
         copy.@disableDefaultRuleSets = disableDefaultRuleSets
@@ -122,6 +136,7 @@ class Detekt extends AbstractQualityFeature {
     static void merge(Detekt o1, Detekt o2) {
         AbstractQualityFeature.merge(o1, o2)
         o1.setParallel((boolean) (o1.parallelSet ? o1.parallel : o2.parallel))
+        o1.setFailFast((boolean) (o1.failFastSet ? o1.failFast : o2.failFast))
         o1.setBuildUponDefaultConfig((boolean) (o1.buildUponDefaultConfigSet ? o1.buildUponDefaultConfig : o2.buildUponDefaultConfig))
         o1.setDisableDefaultRuleSets((boolean) (o1.disableDefaultRuleSetsSet ? o1.disableDefaultRuleSets : o2.disableDefaultRuleSets))
         o1.configFile = o1.configFile ?: o2.configFile

--- a/plugins/base-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/base/plugins/Detekt.groovy
+++ b/plugins/base-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/base/plugins/Detekt.groovy
@@ -44,7 +44,7 @@ class Detekt extends AbstractQualityFeature {
 
     Detekt(ProjectConfigurationExtension config, Project project) {
         super(config, project, PLUGIN_ID, 'detekt')
-        toolVersion = '1.2.2'
+        toolVersion = '1.4.0'
     }
 
     @Override

--- a/plugins/detekt-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/detekt/DetektPlugin.groovy
+++ b/plugins/detekt-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/detekt/DetektPlugin.groovy
@@ -220,6 +220,7 @@ class DetektPlugin extends AbstractKordampPlugin {
         detektTask.config.setFrom(config.quality.detekt.configFile)
         detektTask.baseline.set(config.quality.detekt.baselineFile)
         detektTask.parallel = config.quality.detekt.parallel
+        detektTask.failFast = config.quality.detekt.failFast
         detektTask.buildUponDefaultConfig = config.quality.detekt.buildUponDefaultConfig
         detektTask.disableDefaultRuleSets = config.quality.detekt.disableDefaultRuleSets
         detektTask.ignoreFailures = config.quality.detekt.ignoreFailures


### PR DESCRIPTION
This PR adds the configuration parameter `failFast` (with a default false).

Depends on PR #251 to be merged beforehand.