### PR TITLE
SonarPlugin Documentation (first draft) + activation of configProperties

### DIFF
--- a/docs/guide/src/docs/asciidoc/plugins.adoc
+++ b/docs/guide/src/docs/asciidoc/plugins.adoc
@@ -38,5 +38,6 @@ include::{includedir}/plugins/sourcehtml-gradle-plugin.adoc[]
 include::{includedir}/plugins/sourcestats-gradle-plugin.adoc[]
 include::{includedir}/plugins/sourcexref-gradle-plugin.adoc[]
 include::{includedir}/plugins/spotbugs-gradle-plugin.adoc[]
+include::{includedir}/plugins/sonar-gradle-plugin.adoc[]
 include::{includedir}/plugins/testing-gradle-plugin.adoc[]
 :leveloffset: 1

--- a/docs/guide/src/docs/asciidoc/plugins/sonar-gradle-plugin.adoc
+++ b/docs/guide/src/docs/asciidoc/plugins/sonar-gradle-plugin.adoc
@@ -16,6 +16,8 @@ If link:https://www.eclemma.org/jacoco/[JaCoCo] is enabled, the output of the
 For kotlin projects, if link:https://arturbosch.github.io/detekt/[detekt] is enabled, the output of the
 <<_task_aggregate_detekt,aggregateDetekt>> task is also used as input for the sonarqube task.
 
+Data defined in the DSL’s `config.info` block will be used to provide additional information to SonarQube.
+
 [[_org_kordamp_gradle_sonar_dsl]]
 == DSL
 
@@ -61,12 +63,12 @@ This block should be configured on the root project.
 | `config.quality.sonar.excludes`                 | `sonar.exclusions`                     |
 | `config.coverage.jacoco.aggregateReportXmlFile` | `sonar.coverage.jacoco.xmlReportPaths` | if jacoco is enabled
 | 'build/reports/detekt/aggregate.xml'            | `sonar.kotlin.detekt.reportPaths`      | if detekt is enabled
+| `config.info.description`                       | `sonar.projectDescription`             |
+| `config.info.links.website`                     | `sonar.links.homepage`                 |
+| `config.info.ciManagement.url`                  | `sonar.links.ci`                       |
+| `config.info.issueManagement.url`               | `sonar.links.issue`                    |
+| `config.info.scm.url`                           | `sonar.links.scm`                      |
 |===
-
-The SonarQube property `sonar.tests` is enriched automatically with the respective test sets,
-if any of the <<_org_kordamp_gradle_integrationtest,org.kordamp.gradle.integration-test>>
-or <<_org_kordamp_gradle_functionaltest,org.kordamp.gradle.functional-test>> plugins are enabled. +
-Likewise, the SonarQube property `sonar.java.test.binaries`
 
 .Methods
 

--- a/docs/guide/src/docs/asciidoc/plugins/sonar-gradle-plugin.adoc
+++ b/docs/guide/src/docs/asciidoc/plugins/sonar-gradle-plugin.adoc
@@ -19,6 +19,8 @@ For kotlin projects, if link:https://arturbosch.github.io/detekt/[detekt] is ena
 [[_org_kordamp_gradle_sonar_dsl]]
 == DSL
 
+// TODO configProperties is currently defined, but not actually used, or is it?
+
 [source,groovy]
 [subs="+macros"]
 ----
@@ -30,7 +32,6 @@ config {
             username
             projectKey
             ignoreFailures
-            configProperties
         }
     }
 }
@@ -46,7 +47,7 @@ config {
 | projectKey       | String              | no       | $username + '_' + ${project.rootProject.name} | The project's unique key.
 | ignoreFailures   | boolean             | no       | true                                          |
 | excludedProjects | Set<Project>        | no       | []                                            | Projects in the set are excluded from aggregation
-| configProperties | Map<String, Object> | no       | [:]                                           |
+//| configProperties | Map<String, Object> | no       | [:]                                           | // TODO configProperties is currently defined, but not actually used, or is it?
 |===
 
 This block should be configured on the root project.

--- a/docs/guide/src/docs/asciidoc/plugins/sonar-gradle-plugin.adoc
+++ b/docs/guide/src/docs/asciidoc/plugins/sonar-gradle-plugin.adoc
@@ -11,9 +11,9 @@ applies:: `<<_org_kordamp_gradle_base,org.kordamp.gradle.base>>`, +
 `link:https://plugins.gradle.org/plugin/org.sonarqube[org.sonarsource.scanner.gradle:sonarqube-gradle-plugin]`
 
 Configures the SonarQube gradle plugin to analyze your project with link:https://www.sonarqube.org/[SonarQube]. +
-If link:https://www.eclemma.org/jacoco/[JaCoCo] is enabled, the output of the
+If <<_org_kordamp_gradle_jacoco,org.kordamp.gradle.jacoco>> is enabled, the output of the
 <<_task_aggregate_jacoco_report,aggregateJacocoReport>> task is used as input for the sonarqube task. +
-For kotlin projects, if link:https://arturbosch.github.io/detekt/[detekt] is enabled, the output of the
+For kotlin projects, if <<_org_kordamp_gradle_detekt,org.kordamp.gradle.detekt>> is enabled, the output of the
 <<_task_aggregate_detekt,aggregateDetekt>> task is also used as input for the sonarqube task.
 
 Data defined in the DSL’s `config.info` block will be used to provide additional information to SonarQube.

--- a/docs/guide/src/docs/asciidoc/plugins/sonar-gradle-plugin.adoc
+++ b/docs/guide/src/docs/asciidoc/plugins/sonar-gradle-plugin.adoc
@@ -1,0 +1,87 @@
+
+[[_org_kordamp_gradle_sonar]]
+= SonarQube
+
+[horizontal]
+id:: `org.kordamp.gradle.sonar`
+class:: `org.kordamp.gradle.plugin.coveralls.SonarPlugin`
+(link:api/org/kordamp/gradle/plugin/sonar/SonarPlugin.html[groovydoc],
+link:api-html/org/kordamp/gradle/plugin/sonar/SonarPlugin.html[source])
+applies:: `<<_org_kordamp_gradle_base,org.kordamp.gradle.base>>`, +
+`link:https://plugins.gradle.org/plugin/org.sonarqube[org.sonarsource.scanner.gradle:sonarqube-gradle-plugin]`
+
+Configures the SonarQube gradle plugin to analyze your project with link:https://www.sonarqube.org/[SonarQube]. +
+If link:https://www.eclemma.org/jacoco/[JaCoCo] is enabled, the output of the
+<<_task_aggregate_jacoco_report,aggregateJacocoReport>> task is used as input for the sonarqube task. +
+For kotlin projects, if link:https://arturbosch.github.io/detekt/[detekt] is enabled, the output of the
+<<_task_aggregate_detekt,aggregateDetekt>> task is also used as input for the sonarqube task.
+
+[[_org_kordamp_gradle_sonar_dsl]]
+== DSL
+
+[source,groovy]
+[subs="+macros"]
+----
+config {
+    quality {
+        sonar {
+            enabled
+            hostUrl
+            username
+            projectKey
+            ignoreFailures
+            configProperties
+        }
+    }
+}
+----
+
+.Properties
+[options="header", cols="5*"]
+|===
+| Name             | Type                | Required | Default Value                                 | Description
+| enabled          | boolean             | no       | true                                          | Disables `org.kordamp.gradle.sonar` plugin if `false`
+| hostUrl          | String              | no       | 'https://sonarcloud.io'                       | The server URL to publish the sonar analysis to
+| username         | String              | yes      |                                               | The login or authentication token of a SonarQube user with Execute Analysis permission on the project.
+| projectKey       | String              | no       | $username + '_' + ${project.rootProject.name} | The project's unique key.
+| ignoreFailures   | boolean             | no       | true                                          |
+| excludedProjects | Set<Project>        | no       | []                                            | Projects in the set are excluded from aggregation
+| configProperties | Map<String, Object> | no       | [:]                                           |
+|===
+
+This block should be configured on the root project.
+
+.Mapping of Kordamp to SonarQube properties
+[options="header", cols="3*"]
+|===
+| Plugin Property | SonarQube Property | Comment
+| `config.quality.sonar.hostUrl`                  | `sonar.host.url`                       |
+| `config.quality.sonar.projectKey`               | `sonar.projectKey`                     |
+| `config.quality.sonar.excludes`                 | `sonar.exclusions`                     |
+| `config.coverage.jacoco.aggregateReportXmlFile` | `sonar.coverage.jacoco.xmlReportPaths` | if jacoco is enabled
+| 'build/reports/detekt/aggregate.xml'            | `sonar.kotlin.detekt.reportPaths`      | if detekt is enabled
+|===
+
+The SonarQube property `sonar.tests` is enriched automatically with the respective test sets,
+if any of the <<_org_kordamp_gradle_integrationtest,org.kordamp.gradle.integration-test>>
+or <<_org_kordamp_gradle_functionaltest,org.kordamp.gradle.functional-test>> plugins are enabled. +
+Likewise, the SonarQube property `sonar.java.test.binaries`
+
+.Methods
+
+void exclude(String):: Adds a source exclusion rule (Ant pattern).
+void excludeProject(Project):: Exclude a project from sonar analysis.
+
+[[_org_kordamp_gradle_sonar_tasks]]
+== Tasks
+
+[[_task_sonarqube]]
+=== Sonarqube
+
+Runs the code analysis with SonarQube. +
+Consumes settings from `config.quality.<<_org_kordamp_gradle_sonar_dsl,sonar>>`. +
+This task is added to the root project.
+
+[horizontal]
+Name:: sonarqube
+Type:: `org.sonarqube.gradle.SonarQubeTask`

--- a/docs/guide/src/docs/asciidoc/plugins/sonar-gradle-plugin.adoc
+++ b/docs/guide/src/docs/asciidoc/plugins/sonar-gradle-plugin.adoc
@@ -21,8 +21,6 @@ Data defined in the DSL’s `config.info` block will be used to provide addition
 [[_org_kordamp_gradle_sonar_dsl]]
 == DSL
 
-// TODO configProperties is currently defined, but not actually used, or is it?
-
 [source,groovy]
 [subs="+macros"]
 ----
@@ -34,6 +32,7 @@ config {
             username
             projectKey
             ignoreFailures
+            configProperties
         }
     }
 }
@@ -49,7 +48,7 @@ config {
 | projectKey       | String              | no       | $username + '_' + ${project.rootProject.name} | The project's unique key.
 | ignoreFailures   | boolean             | no       | true                                          |
 | excludedProjects | Set<Project>        | no       | []                                            | Projects in the set are excluded from aggregation
-//| configProperties | Map<String, Object> | no       | [:]                                           | // TODO configProperties is currently defined, but not actually used, or is it?
+| configProperties | Map<String, Object> | no       | [:]                                           | Additional sonar properties that are passed to sonar as such
 |===
 
 This block should be configured on the root project.

--- a/docs/guide/src/docs/asciidoc/project-dsl.adoc
+++ b/docs/guide/src/docs/asciidoc/project-dsl.adoc
@@ -43,6 +43,7 @@ config {
         <<_org_kordamp_gradle_errorprone,errorprone>> { ... }
         <<_org_kordamp_gradle_pmd,pmd>> { ... }
         <<_org_kordamp_gradle_spotbugs,spotbugs>> { ... }
+        <<_org_kordamp_gradle_sonar,sonar>> { ... }
     }
 }
 ----

--- a/plugins/base-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/base/plugins/Sonar.groovy
+++ b/plugins/base-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/base/plugins/Sonar.groovy
@@ -38,7 +38,7 @@ class Sonar extends AbstractFeature {
     String hostUrl = 'https://sonarcloud.io'
     String username
     String projectKey
-    Map<String, Object> configProperties = [:] // TODO currently not used, or is it?
+    Map<String, Object> configProperties = [:]
     Set<String> excludes = new LinkedHashSet<>()
     final Set<Project> excludedProjects = new LinkedHashSet<>()
 

--- a/plugins/base-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/base/plugins/Sonar.groovy
+++ b/plugins/base-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/base/plugins/Sonar.groovy
@@ -38,7 +38,7 @@ class Sonar extends AbstractFeature {
     String hostUrl = 'https://sonarcloud.io'
     String username
     String projectKey
-    Map<String, Object> configProperties = [:]
+    Map<String, Object> configProperties = [:] // TODO currently not used, or is it?
     Set<String> excludes = new LinkedHashSet<>()
     final Set<Project> excludedProjects = new LinkedHashSet<>()
 

--- a/plugins/base-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/base/plugins/Sonar.groovy
+++ b/plugins/base-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/base/plugins/Sonar.groovy
@@ -139,6 +139,5 @@ class Sonar extends AbstractFeature {
         o1.username = o1.username ?: o2.username
         CollectionUtils.merge(o1.configProperties, o2?.configProperties)
         CollectionUtils.merge(o1.excludes, o2?.excludes)
-        o1.ignoreFailures = o1.ignoreFailuresSet ? o1.getIgnoreFailures() : o2.getIgnoreFailures()
     }
 }

--- a/plugins/sonar-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/sonar/SonarPlugin.groovy
+++ b/plugins/sonar-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/sonar/SonarPlugin.groovy
@@ -106,9 +106,15 @@ class SonarPlugin extends AbstractKordampPlugin {
         sonarExt.properties(new Action<SonarQubeProperties>() {
             @Override
             void execute(SonarQubeProperties p) {
+                ProjectConfigurationExtension effectiveConfig = resolveEffectiveConfig(project)
                 p.property('sonar.host.url', config.quality.sonar.hostUrl)
                 p.property('sonar.projectKey', config.quality.sonar.projectKey)
                 p.property('sonar.exclusions', config.quality.sonar.excludes.join(','))
+                p.property('sonar.projectDescription', effectiveConfig.info.description)
+                p.property('sonar.links.homepage', effectiveConfig.info.links.website)
+                p.property('sonar.links.scm', effectiveConfig.info.scm.url)
+                p.property('sonar.links.issue', effectiveConfig.info.issueManagement.url)
+                p.property('sonar.links.ci', effectiveConfig.info.ciManagement.url)
                 if (config.coverage.jacoco.enabled) {
                     p.property('sonar.coverage.jacoco.xmlReportPaths', config.coverage.jacoco.aggregateReportXmlFile)
                 }


### PR DESCRIPTION
* Documentation: First draft - needs a thorough review and most likely adjustments
* Plugin amendments
  * `ignoreFailures` does not require explicit merging (`AbstractQualityFeature.merge` does it already)
  * Activate `configProperties`, so it is passed to sonar
  * configured some additional sonar-properties, derived from `config.info`, only apply them if they have not been configured otherwise (e.g. through `configProperties`)