### PR TITLE
Fix ant-patterns in guide

### DIFF
--- a/docs/guide/src/docs/asciidoc/plugins/licensing-gradle-plugin.adoc
+++ b/docs/guide/src/docs/asciidoc/plugins/licensing-gradle-plugin.adoc
@@ -166,7 +166,7 @@ copyrightYear:: config.info.copyrightYear
 author:: config.info.resolveAuthors().join(', ')
 license:: primaryLicense.id?.spdx()
 
-The following exclusions patterns are added by default: '**/*.png', 'META-INF/services/*'.
+The following exclusions patterns are added by default: 'pass:[**/*].png', 'META-INF/services/*'.
 
 [[_extension_download_licenses]]
 === DownloadLicensesExtension

--- a/docs/guide/src/docs/asciidoc/plugins/sourcehtml-gradle-plugin.adoc
+++ b/docs/guide/src/docs/asciidoc/plugins/sourcehtml-gradle-plugin.adoc
@@ -71,24 +71,24 @@ config {
 
 [options="header", cols="5*"]
 |===
-| Name                  | Type           | Required | Default Value                          | Description
-| srcDirs               | FileCollection | no       |                                        |
-| destDir               | File           | no       | "${project.buildDir}/docs/source-html" |
-| includes              | String         | no       | '**/*.java,**/*.groovy'                |
-| outputFormat          | String         | no       | 'html'                                 |
-| tabs                  | int            | no       | 4                                      |
-| style                 | String         | no       | 'kawa'                                 | Valid values are 'kawa', 'monochrome', 'eclipse'
-| lineAnchorPrefix      | String         | no       | ''                                     |
-| horizontalAlignment   | String         | no       | 'left'                                 |
-| showLineNumbers       | boolean        | no       | true                                   |
-| showFileName          | boolean        | no       | true                                   |
-| showDefaultTitle      | boolean        | no       | true                                   |
-| showTableBorder       | boolean        | no       | false                                  |
-| includeDocumentHeader | boolean        | no       | true                                   |
-| includeDocumentFooter | boolean        | no       | true                                   |
-| addLineAnchors        | boolean        | no       | true                                   |
-| useShortFileName      | boolean        | no       | true                                   |
-| overwrite             | boolean        | no       | true                                   |
+| Name                  | Type           | Required | Default Value                                       | Description
+| srcDirs               | FileCollection | no       |                                                     |
+| destDir               | File           | no       | "${project.buildDir}/docs/source-html"              |
+| includes              | String         | no       | 'pass:[**/*].java,pass:[**/*].groovy' |
+| outputFormat          | String         | no       | 'html'                                              |
+| tabs                  | int            | no       | 4                                                   |
+| style                 | String         | no       | 'kawa'                                              | Valid values are 'kawa', 'monochrome', 'eclipse'
+| lineAnchorPrefix      | String         | no       | ''                                                  |
+| horizontalAlignment   | String         | no       | 'left'                                              |
+| showLineNumbers       | boolean        | no       | true                                                |
+| showFileName          | boolean        | no       | true                                                |
+| showDefaultTitle      | boolean        | no       | true                                                |
+| showTableBorder       | boolean        | no       | false                                               |
+| includeDocumentHeader | boolean        | no       | true                                                |
+| includeDocumentFooter | boolean        | no       | true                                                |
+| addLineAnchors        | boolean        | no       | true                                                |
+| useShortFileName      | boolean        | no       | true                                                |
+| overwrite             | boolean        | no       | true                                                |
 |===
 
 [[_sourcehtml_overview]]
@@ -98,7 +98,7 @@ config {
 |===
 | Name           | Type   | Required | Default Value                          | Description
 | destDir        | File   | no       | "${project.buildDir}/docs/source-html" |
-| pattern        | String | no       | '**/*.html'                            |
+| pattern        | String | no       | 'pass:[**/*].html'                     |
 | windowTitle    | String | no       | "$project.name $project.version"       |
 | docTitle       | String | no       | "$project.name $project.version"       |
 | docDescription | String | no       |                                        |


### PR DESCRIPTION
Fixes wrong interpretation of the ant-style patterns in 

- licensing-gradle-plugin
- source-html-gradle-plugin

Patterns like ```'**/*.java,**/*.groovy'``` turned out as ```'/.java,/.groovy'```

Note: I was considering also including a note that the source-html plugin only works with java or groovy code (but not with kotlin or scala, I guess), but I refrained from it to not pollute the PR.