### PR TITLE
[267] - temmporarily downgrade version plugin to 2.11.0

### DIFF
--- a/plugins/buildinfo-gradle-plugin/buildinfo-gradle-plugin.gradle
+++ b/plugins/buildinfo-gradle-plugin/buildinfo-gradle-plugin.gradle
@@ -18,5 +18,6 @@
 dependencies {
     api project(':base-gradle-plugin')
 
-    api 'gradle.plugin.net.nemerosa:versioning:2.12.0'
+    // TODO bump to >2.12.0 as soon as available (See https://github.com/nemerosa/versioning/pull/74)
+    api 'gradle.plugin.net.nemerosa:versioning:2.11.0'
 }

--- a/plugins/buildinfo-gradle-plugin/buildinfo-gradle-plugin.gradle
+++ b/plugins/buildinfo-gradle-plugin/buildinfo-gradle-plugin.gradle
@@ -18,6 +18,5 @@
 dependencies {
     api project(':base-gradle-plugin')
 
-    // TODO bump to >2.12.0 as soon as available (See https://github.com/nemerosa/versioning/pull/74)
-    api 'gradle.plugin.net.nemerosa:versioning:2.11.0'
+    api 'gradle.plugin.net.nemerosa:versioning:2.12.1'
 }


### PR DESCRIPTION
Related to #267

temporary downgrade until we get a nemrose/versioning release >2.12.0 pulling in grgit-4.0.1