### PR TITLE
[Kotlindoc] - fix aggregation of kotlindoc for multi-module project

### DIFF
--- a/docs/guide/src/docs/asciidoc/plugins/guide-gradle-plugin.adoc
+++ b/docs/guide/src/docs/asciidoc/plugins/guide-gradle-plugin.adoc
@@ -94,6 +94,7 @@ config {
 guide {
     javadocApiDir
     groovydocApiDir
+    kotlindocApiDir
     sourceHtmlDir
     sourceXrefDir
 }
@@ -104,6 +105,7 @@ guide {
 | Name            | Type   | Required | Default Value | Description
 | javadocApiDir   | String | no       | 'api'         | Director where javadoc will be copied
 | groovydocApiDir | String | no       | 'gapi'        | Director where groovydoc will be copied
+| kotlindocApiDir | String | no       | 'kapi'        | Director where kotlindoc will be copied
 | sourceHtmlDir   | String | no       | 'api-html'    | Director where source-html will be copied
 | sourceXrefDir   | String | no       | 'api-xref'    | Director where source-xref will be copied
 |===
@@ -132,6 +134,7 @@ Creates an Asciidoctor based guide. Depends on the output of the following tasks
  * `asciidoctor`
  * `aggregateJavadoc` (if enabled)
  * `aggregateGroovydoc` (if enabled)
+ * `aggregateKotlindocHtml` (if enabled)
  * `aggregateSourceHtml` (if enabled)
  * `aggregateSourceXref` (if enabled)
 

--- a/plugins/guide-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/guide/GuideExtension.groovy
+++ b/plugins/guide-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/guide/GuideExtension.groovy
@@ -28,6 +28,7 @@ import org.gradle.api.Project
 class GuideExtension {
     String javadocApiDir = 'api'
     String groovydocApiDir = 'gapi'
+    String kotlindocApiDir = 'kapi'
     String sourceHtmlDir = 'api-html'
     String sourceXrefDir = 'api-xref'
 

--- a/plugins/guide-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/guide/GuidePlugin.groovy
+++ b/plugins/guide-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/guide/GuidePlugin.groovy
@@ -180,6 +180,12 @@ class GuidePlugin extends AbstractKordampPlugin {
                             t.from(task.destinationDir) { into extension.groovydocApiDir }
                         }
 
+                        task = project.rootProject.tasks.findByName('aggregateKotlindocHtml')
+                        if (task?.enabled) {
+                            t.dependsOn task
+                            t.from(task.outputDirectory) { into extension.kotlindocApiDir }
+                        }
+
                         task = project.rootProject.tasks.findByName(SourceHtmlPlugin.AGGREGATE_SOURCE_HTML_TASK_NAME)
                         if (task?.enabled) {
                             t.dependsOn task

--- a/plugins/kotlindoc-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/kotlindoc/KotlindocPlugin.groovy
+++ b/plugins/kotlindoc-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/kotlindoc/KotlindocPlugin.groovy
@@ -262,6 +262,7 @@ class KotlindocPlugin extends AbstractKordampPlugin {
                         t.dokkaRuntime = project.configurations.findByName(DOKKA_RUNTIME_CONFIGURATION_NAME)
                         t.extensions.add('multiplatform', project.container(GradlePassConfigurationImpl))
                         t.extensions.add('configuration', new GradlePassConfigurationImpl())
+                        t.subProjects = project.subprojects.collect { it.name }.toList()
                         applyConfiguration(config.docs.kotlindoc, t, format, formatName)
                         t.outputDirectory = config.docs.kotlindoc.outputDirectory.absolutePath + File.separator + 'aggregate-' + formatName
                     }

--- a/plugins/kotlindoc-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/kotlindoc/KotlindocPlugin.groovy
+++ b/plugins/kotlindoc-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/kotlindoc/KotlindocPlugin.groovy
@@ -262,7 +262,9 @@ class KotlindocPlugin extends AbstractKordampPlugin {
                         t.dokkaRuntime = project.configurations.findByName(DOKKA_RUNTIME_CONFIGURATION_NAME)
                         t.extensions.add('multiplatform', project.container(GradlePassConfigurationImpl))
                         t.extensions.add('configuration', new GradlePassConfigurationImpl())
-                        t.subProjects = project.subprojects.collect { it.name }.toList()
+                        t.subProjects = project.childProjects.values().findAll { p ->
+                            p.pluginManager.hasPlugin('org.jetbrains.kotlin.jvm')
+                        }.collect { it.name }.toList()
                         applyConfiguration(config.docs.kotlindoc, t, format, formatName)
                         t.outputDirectory = config.docs.kotlindoc.outputDirectory.absolutePath + File.separator + 'aggregate-' + formatName
                     }


### PR DESCRIPTION
The task `aggregateKotlindocHtml` did not actually process the (correctly created) kotlindoc of the individual submodules. Therefore the aggregated kotlindoc was empty.

This PR fixes this and also unhances the guide plugin to process kotlindoc (in a similar manner to groovydoc) and allows to publish it to e.g. the `gh-pages` branch.

I still struggle with two aspects getting my configuration right (assuming it's a configuration issue on my side). I have created a reproducer project and would be grateful for some guidance. I pollute this PR, as the reproducer currently only works with the changes in this PR. However, if you prefer, I am perfectly willing to open a dedicated issue for that once the guide aggregation is working correctly.

https://github.com/ursjoss/kordamp-kotlindoc-reproducer