### PR TITLE
[Guide] - Improve Documentation & initGuide

### DIFF
--- a/docs/guide/src/docs/asciidoc/plugins/guide-gradle-plugin.adoc
+++ b/docs/guide/src/docs/asciidoc/plugins/guide-gradle-plugin.adoc
@@ -27,7 +27,7 @@ The following attributes will be added to the default `asciidoctor` task if they
 | sectanchors            | true
 | numbered               | true
 | linkattrs              | true
-| imagesdir              | 'images'
+| imagesdir              | 'images' (`src/docs/resources/images`)
 | linkcss                | true
 | source-highlighter     | 'coderay'
 | coderay-linenums-mode  | 'table'

--- a/plugins/guide-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/guide/GuidePlugin.groovy
+++ b/plugins/guide-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/guide/GuidePlugin.groovy
@@ -244,6 +244,7 @@ class GuidePlugin extends AbstractKordampPlugin {
         GuideExtension extension = project.extensions.findByType(GuideExtension)
 
         project.file(ASCIIDOCTOR_RESOURCE_DIR).mkdirs()
+        project.file("$ASCIIDOCTOR_RESOURCE_DIR/$IMAGES_DIR").mkdirs()
         File asciidocDir = project.file(ASCIIDOCTOR_SRC_DIR)
         asciidocDir.mkdirs()
 

--- a/plugins/guide-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/guide/GuidePlugin.groovy
+++ b/plugins/guide-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/guide/GuidePlugin.groovy
@@ -47,6 +47,7 @@ class GuidePlugin extends AbstractKordampPlugin {
     static final String ASCIIDOCTOR = 'asciidoctor'
     static final String ASCIIDOCTOR_SRC_DIR = 'src/docs/asciidoc'
     static final String ASCIIDOCTOR_RESOURCE_DIR = 'src/docs/resources'
+    static final String IMAGES_DIR = 'images'
 
     Project project
 
@@ -94,7 +95,7 @@ class GuidePlugin extends AbstractKordampPlugin {
                 checkAttribute(attrs, t.attributes, 'sectanchors', true)
                 checkAttribute(attrs, t.attributes, 'numbered', true)
                 checkAttribute(attrs, t.attributes, 'linkattrs', true)
-                checkAttribute(attrs, t.attributes, 'imagesdir', 'images')
+                checkAttribute(attrs, t.attributes, 'imagesdir', IMAGES_DIR)
                 checkAttribute(attrs, t.attributes, 'linkcss', true)
                 checkAttribute(attrs, t.attributes, 'source-highlighter', 'coderay')
                 checkAttribute(attrs, t.attributes, 'coderay-linenums-mode', 'table')
@@ -250,7 +251,13 @@ class GuidePlugin extends AbstractKordampPlugin {
 
         File index = touchFile(project.file("${asciidocDir}/index.adoc"))
         if (!index.text) {
-            index.text = """|= {project-title}
+            index.text = """|ifndef::imagesdir[]
+                            |:imagesdir: ../resources/$IMAGES_DIR
+                            |endif::[]
+                            |ifndef::includedir[]
+                            |:includedir: .
+                            |endif::[]
+                            |= {project-title}
                             |:author: {project-author}
                             |:revnumber: {project-version}
                             |:toclevels: 4


### PR DESCRIPTION
Resolves #262 

- Guide: Explicitly mention the location of the `imagesDir` (`src/docs/resources/images`)
- initGuide: Create the `imagesDir` so it can be found more easily even without consulting the guide
- initGuide: Define `magesdir` and `includedir` for IntelliJ to be able to resolve them