### PR TITLE
[331] - Fix regression, plugin must be enabled explicitly

### DIFF
--- a/plugins/base-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/base/plugins/Licensing.groovy
+++ b/plugins/base-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/base/plugins/Licensing.groovy
@@ -47,9 +47,7 @@ class Licensing extends AbstractFeature {
 
     @Override
     protected void normalizeEnabled() {
-        if (!enabledSet) {
-            setEnabled(isApplied())
-        }
+        // empty. Must be explicitly enabled
     }
 
     @Override


### PR DESCRIPTION
Resolves #331 (regression introduced in 157cb0972edd349e23bdd0434fadc872667010d9)