### PR TITLE
bundle reports after failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,3 +33,9 @@ jobs:
       - uses: eskatos/gradle-command-action@v1
         with:
           arguments: build -S
+      - name: Show Reports
+        uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+           name: reports-${{ runner.os }}
+           path: build/reports/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,4 +38,4 @@ jobs:
         if: failure()
         with:
            name: reports-${{ runner.os }}
-           path: build/reports/
+           path: build/


### PR DESCRIPTION
I'm not sure if the build creates aggregate reports but if it does then this will crate a bundle on failure