### PR TITLE
Switched from creating tasks to register for Jacoco and Jar plugins

### DIFF
--- a/plugins/jacoco-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/jacoco/JacocoPlugin.groovy
+++ b/plugins/jacoco-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/jacoco/JacocoPlugin.groovy
@@ -251,7 +251,7 @@ class JacocoPlugin extends AbstractKordampPlugin {
         Task jacocoReportTask = project.tasks.findByName(taskName)
 
         if (!jacocoReportTask) {
-            jacocoReportTask = project.tasks.create(taskName, JacocoReport) { t ->
+            jacocoReportTask = project.tasks.register(taskName, JacocoReport) { t ->
                 t.dependsOn testTask
                 t.group = 'Reporting'
                 t.description = "Generates code coverage report for the ${testTask.name} task."

--- a/plugins/jar-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/jar/JarPlugin.groovy
+++ b/plugins/jar-gradle-plugin/src/main/groovy/org/kordamp/gradle/plugin/jar/JarPlugin.groovy
@@ -135,7 +135,7 @@ class JarPlugin extends AbstractKordampPlugin {
         Task jarTask = project.tasks.findByName(taskName)
 
         if (!jarTask) {
-            jarTask = project.tasks.create(taskName, Jar) {
+            jarTask = project.tasks.register(taskName, Jar) {
                 dependsOn project.sourceSets.main.output
                 group = org.gradle.api.plugins.BasePlugin.BUILD_GROUP
                 description = 'Assembles a jar archive'


### PR DESCRIPTION
The Jacoco and Jar plugins were still using `create` instead of `register`