### PR TITLE
fix: honoring MergeStrategy in docs, change OVERWRITE -> OVERRIDE

### DIFF
--- a/docs/guide/src/docs/asciidoc/plugins/licensing-gradle-plugin.adoc
+++ b/docs/guide/src/docs/asciidoc/plugins/licensing-gradle-plugin.adoc
@@ -54,7 +54,7 @@ config {
 | licenses           | LicenseSet          | yes      |               | This block maps to the `<licenses>` block in POM. +
                                                                         At least one nested `license` block must be defined.
 | inherits           | boolean             | no       | true          | Whether to inherit values from a parent `POM`.
-| mergeStrategy      | MergeStrategy       | no       | UNIQUE        | One of `PREPEND`, `APPEND`, `UNIQUE`, `OVERWRITE`.
+| mergeStrategy      | MergeStrategy       | no       | UNIQUE        | One of `PREPEND`, `APPEND`, `UNIQUE`, `OVERRIDE`.
 |===
 
 The value of `inherits` cannot be changed once it has been set.


### PR DESCRIPTION
Hi there:

Licensing plugin docs mentioned OVERWRITE as mergeStrategy option, but applying plugin it complained with:

```
* What went wrong:
A problem occurred evaluating root project 'matter'.
> No enum constant org.kordamp.gradle.plugin.base.plugins.MergeStrategy.OVERWRITE
```

Checking source code I realized it should be **OVERRIDE** instead of **OVERWRITE**.

Cheers
Mario